### PR TITLE
linux support for cmake builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,10 @@
 /nativeLibraries
 /.settings
 /.project
+
+/bin/
+/CMakeFiles/
+/lib/
+/cmake_install.cmake
+/CMakeCache.txt
+/Makefile

--- a/JCudnnJNI/CMakeLists.txt
+++ b/JCudnnJNI/CMakeLists.txt
@@ -29,7 +29,8 @@ set(CUDA_cuDNN_INCLUDE "NOT-DEFINED" CACHE PATH "cuDNN include directory")
 
 include_directories (${CUDA_cuDNN_INCLUDE} REQUIRED)
 find_library(CUDA_cuDNN_LIBRARY NAMES libcudnn.so cudnn.lib
-             DOC "cuDNN library")
+             DOC "cuDNN library"
+             PATH_SUFFIXES /lib64)
 target_link_libraries(${PROJECT_NAME} ${CUDA_cuDNN_LIBRARY})
 
 target_link_libraries(${PROJECT_NAME}

--- a/README.md
+++ b/README.md
@@ -11,5 +11,15 @@ libraries, but depends on the following libraries:
 Refer to [jcuda-main](https://github.com/jcuda/jcuda-main) for further
 information and build instructions for these libraries.
 
+## Building on Linux
 
+If you have already built and installed jcuda-main, this is a short set of building instractions for linux (provided `$JAVA_HOME` is set). In the project root:
 
+```
+cmake JCudnnJNI/
+make
+
+mvn clean install
+cd JCudnnJava/
+mvn clean install
+```


### PR DESCRIPTION
Added a new path suffix to cmake find_library. Also added some files specific to linux to gitignore paths, and basic compilation instructions for linux in the README.